### PR TITLE
Fixed topic deletion when multiple publishers/subscribers exist on the same topic

### DIFF
--- a/src/rostful_node/ros_interface.py
+++ b/src/rostful_node/ros_interface.py
@@ -128,11 +128,6 @@ class RosInterface(object):
 
         return False
 
-    def repslash(self, string):
-        if string[0] == '/':
-            return string[1:]
-        return string
-
     ##
     # This callback is called when dynamic_reconfigure gets an update on
     # parameter information. Topics which are received through here will be
@@ -142,27 +137,27 @@ class RosInterface(object):
         rospy.logwarn("""[ros_interface] Interface Reconfigure Request: \ntopics : {topics} \nservices : {services} \nactions : {actions}""".format(**config))
         try:
             # convert new topics to a set and then back to a list to ensure uniqueness
-            new_topics = map(self.repslash, list(set(ast.literal_eval(config["topics"]))))
+            new_topics = list(set(ast.literal_eval(config["topics"])))
             self.expose_topics(new_topics)
         except ValueError:
             rospy.logwarn('[ros_interface] Ignored list %s containing malformed topic strings. Fix your input!' % str(config["topics"]))
         try:
             # convert new services to a set and then back to a list to ensure uniqueness
-            new_services = map(self.repslash, list(set(ast.literal_eval(config["services"]))))
+            new_services = list(set(ast.literal_eval(config["services"])))
             self.expose_services(new_services)
         except ValueError:
             rospy.logwarn('[ros_interface] Ignored list %s containing malformed service strings. Fix your input!' % str(config["services"]))
             
         try:
             # convert new actions to a set and then back to a list to ensure uniqueness
-            new_actions = map(self.repslash, list(set(ast.literal_eval(config["actions"]))))
+            new_actions = list(set(ast.literal_eval(config["actions"])))
             self.expose_actions(new_actions)
         except ValueError:
             rospy.logwarn('[ros_interface] Ignored list %s containing malformed action strings. Fix your input!' % str(config["actions"]))
 
         return config
 
-    def add_service(self, service_name, service_type=None):
+    def add_service(self, service_name, ws_name=None, service_type=None):
         rospy.loginfo("[ros_interface] Adding service %s" % service_name)
         resolved_service_name = rospy.resolve_name(service_name)
         if service_name not in self.services_args:
@@ -402,8 +397,8 @@ class RosInterface(object):
     # new topics, or topics which dropped off the ros network.
     def topics_change_cb(self, new_topics, lost_topics):
         # internal lists store topics without the initial slash, but we receive them with it from outside
-        new_topics = map(self.repslash, new_topics)
-        lost_topics = map(self.repslash, lost_topics)
+        new_topics = new_topics
+        lost_topics = lost_topics
         # rospy.logwarn('new topics : %r, lost topics : %r' % (new_topics, lost_topics))
         # convert new topics to a set and then back to a list to ensure uniqueness
         topics_lst = [t for t in list(set(new_topics)) if t in self.topics_args or self.is_regex_match(t, self.topics_waiting)]
@@ -435,8 +430,8 @@ class RosInterface(object):
 
     def services_change_cb(self, new_services, lost_services):
         # internal lists store topics without the initial slash, but we receive them with it from outside
-        new_services = map(self.repslash, new_services)
-        lost_services = map(self.repslash, lost_services)
+        new_services = new_services
+        lost_services = lost_services
         # rospy.logwarn('new services : %r, lost services : %r' % (new_services, lost_services))
         # convert new services to a set and then back to a list to ensure uniqueness
         svc_list = [s for s in list(set(new_services)) if s in self.services_args or self.is_regex_match(s, self.services_waiting)]
@@ -455,8 +450,8 @@ class RosInterface(object):
 
     def actions_change_cb(self, new_actions, lost_actions):
         # internal lists store topics without the initial slash, but we receive them with it from outside
-        new_actions = map(self.repslash, new_actions)
-        lost_actions = map(self.repslash, lost_actions)
+        new_actions = new_actions
+        lost_actions = lost_actions
         # rospy.logwarn('new actions : %r, lost actions : %r', new_actions, lost_actions)
         # convert new actions to a set and then back to a list to ensure uniqueness
         act_list = [a for a in list(set(new_actions)) if a in self.actions_args or self.is_regex_match(a, self.topics_waiting)]

--- a/src/rostful_node/ros_interface.py
+++ b/src/rostful_node/ros_interface.py
@@ -124,7 +124,7 @@ class RosInterface(object):
                 if pattern.match(key):
                     return True
             except:
-                rospy.logwarn('Invalid regex string "%s"!' % cand)
+                rospy.logwarn('[ros_interface] Invalid regex string "%s"!' % cand)
 
         return False
 
@@ -139,59 +139,59 @@ class RosInterface(object):
     # added to the list of topics which are monitored and added to or removed
     # from the view on the REST interface
     def reconfigure(self, config, level):
-        rospy.logwarn("""ROSInterface Reconfigure Request: \ntopics : {topics} \nservices : {services} \nactions : {actions}""".format(**config))
+        rospy.logwarn("""[ros_interface] Interface Reconfigure Request: \ntopics : {topics} \nservices : {services} \nactions : {actions}""".format(**config))
         try:
             # convert new topics to a set and then back to a list to ensure uniqueness
             new_topics = map(self.repslash, list(set(ast.literal_eval(config["topics"]))))
-            self.topics_waiting = new_topics
             self.expose_topics(new_topics)
         except ValueError:
-            rospy.logwarn('Ignored list %s containing malformed topic strings. Fix your input!' % str(config["topics"]))
+            rospy.logwarn('[ros_interface] Ignored list %s containing malformed topic strings. Fix your input!' % str(config["topics"]))
         try:
             # convert new services to a set and then back to a list to ensure uniqueness
             new_services = map(self.repslash, list(set(ast.literal_eval(config["services"]))))
-            self.services_waiting = new_services
             self.expose_services(new_services)
         except ValueError:
-            rospy.logwarn('Ignored list %s containing malformed service strings. Fix your input!' % str(config["services"]))
+            rospy.logwarn('[ros_interface] Ignored list %s containing malformed service strings. Fix your input!' % str(config["services"]))
             
         try:
             # convert new actions to a set and then back to a list to ensure uniqueness
             new_actions = map(self.repslash, list(set(ast.literal_eval(config["actions"]))))
-            self.actions_waiting = new_actions
             self.expose_actions(new_actions)
         except ValueError:
-            rospy.logwarn('Ignored list %s containing malformed action strings. Fix your input!' % str(config["actions"]))
+            rospy.logwarn('[ros_interface] Ignored list %s containing malformed action strings. Fix your input!' % str(config["actions"]))
 
         return config
 
     def add_service(self, service_name, service_type=None):
-        rospy.loginfo("Adding service %s" % service_name)
+        rospy.loginfo("[ros_interface] Adding service %s" % service_name)
         resolved_service_name = rospy.resolve_name(service_name)
+        if service_name not in self.services_args:
+            self.services_args.append(service_name)
+            
         if service_type is None:
             try:
                 service_type = rosservice.get_service_type(resolved_service_name)
                 if not service_type:
-                    rospy.logwarn('Cannot Expose unknown service %s (maybe it is a regex or doesn\'t exist yet?)' % service_name)
+                    rospy.logwarn('[ros_interface] Cannot Expose unknown service %s (maybe it is a regex or doesn\'t exist yet?)' % service_name)
                     self.services_waiting.append(service_name)
                     return False
             except rosservice.ROSServiceIOException, e:
-               rospy.logwarn('Error trying to Expose service {name} : {error}'.format(name=service_name, error=e))
+               rospy.logwarn('[ros_interface] Error trying to Expose service {name} : {error}'.format(name=service_name, error=e))
                self.services_waiting.append(service_name)
                return False
 
         # only create a new backend for the service when it is in the waiting list
         if service_name in self.services_waiting:
             self.services_waiting.remove(service_name)
-            self.services[service_name] = ServiceBack(service_name, service_type)
-
+        
+        self.services[service_name] = ServiceBack(service_name, service_type)
         return True
 
     ##
     # @return false if the service did not exist, true if the connection was
     # deleted.
     def del_service(self, service_name):
-        rospy.loginfo("deleting service %s" % service_name)
+        rospy.loginfo("[ros_interface] Deleting service %s" % service_name)
         if service_name in self.services:
             self.services_waiting.append(service_name)
             self.services.pop(service_name, None)
@@ -202,23 +202,24 @@ class RosInterface(object):
     This exposes a list of services as REST API. services not listed here will be removed from the API
     """
     def expose_services(self, service_names):
-        rospy.loginfo('Exposing services : %r', service_names)
+        rospy.loginfo('[ros_interface] Exposing services : %r', service_names)
 
-        
         if not service_names:
             return
+
+        # look through the new service names received by reconfigure, and add
+        # those services which are not in the existing service args
         for service_name in service_names:
             if not service_name in self.services_args:
                 ret = self.add_service(service_name)
-                #if ret: rospy.loginfo( 'Exposed Service %s', service_name )
 
+        # look through the current service args and delete those values which
+        # will not be valid when the args are replaced with the new ones.
         for service_name in self.services_args:
-            if not service_name in service_names:
+            if not service_name in service_names or not self.is_regex_match(service_name, service_names):
                 ret = self.del_service(service_name)
-                #if ret: rospy.loginfo ( 'Removed Service %s', service_name )
 
         self.services_args = service_names
-
 
     def get_service(self, service_name):
         if service_name in self.services.keys():
@@ -228,30 +229,37 @@ class RosInterface(object):
             return None  # service not exposed
 
     def add_topic(self, topic_name, topic_type=None, allow_pub=True, allow_sub=True):
-        rospy.loginfo("Adding topic %s" % topic_name)
         resolved_topic_name = rospy.resolve_name(topic_name)
+        # this initialises regex topics
         if topic_name not in self.topics_args:
             self.topics_args[topic_name] = -2
+        if self.topics_args[topic_name] >= 0:
+            rospy.loginfo("[ros_interface] Adding topic %s" % topic_name)
 
         if topic_type is None:
             try:
                 topic_type, _, _ = rostopic.get_topic_type(resolved_topic_name)
                 if not topic_type:
-                    rospy.logwarn('Cannot Expose unknown topic %s (maybe it is a regex or doesn\'t exist yet?)' % topic_name)
+                    rospy.logwarn('[ros_interface] Cannot Expose unknown topic %s (maybe it is a regex or doesn\'t exist yet?)' % topic_name)
                     self.topics_waiting.append(topic_name)
                     return False
             except rosservice.ROSServiceIOException, e:
-                rospy.logwarn('Error trying to Expose topic {name} : {error}'.format(name=topic_name, error=e))
+                rospy.logwarn('[ros_interface] Error trying to Expose topic {name} : {error}'.format(name=topic_name, error=e))
                 self.topics_waiting.append(topic_name)
                 return False
 
         if topic_name in self.topics_waiting_del.keys() > 0:
             # here the intent is obviously to erase the old homonym topic data
             self.topics_waiting_del.pop(topic_name, None)
-        # if the topic didn't exist yet, create a backend for it and remove it from the waiting list.
-        if topic_name in self.topics_waiting or self.topics_args[topic_name] == -2:
-            self.topics[topic_name] = TopicBack(topic_name, topic_type, allow_pub=allow_pub, allow_sub=allow_sub)
+
+        # if this is a regex match topic, it will not be in the waiting list
+        # just after it is initialised above
+        if topic_name in self.topics_waiting:
             self.topics_waiting.remove(topic_name)
+        # if the topic didn't exist yet, create a backend
+        if self.topics_args[topic_name] == -2:
+            self.topics[topic_name] = TopicBack(topic_name, topic_type, allow_pub=allow_pub, allow_sub=allow_sub)
+
 
         self.topics_args[topic_name] += 1
         
@@ -263,7 +271,7 @@ class RosInterface(object):
     def del_topic(self, topic_name, noloss=False):
         # can only delete topic if we have it in the topic list
         if topic_name in self.topics:
-            rospy.loginfo("Deleting topic %s" % topic_name)
+            rospy.loginfo("[ros_interface] Deleting topic %s" % topic_name)
             # if there is more than one connection to the topic, we decrement
             # the count
             if self.topics_args[topic_name] > 1:
@@ -294,20 +302,22 @@ class RosInterface(object):
     This exposes a list of topics as REST API. topics not listed here will be removed from the API
     """
     def expose_topics(self, topic_names, allow_pub=True, allow_sub=True):
-        rospy.loginfo('Exposing topics : %r', topic_names)
+        rospy.loginfo('[ros_interface] Exposing topics : %r', topic_names)
         if not topic_names:
             return
-        # Adding missing ones
+
+        # look through the new topic names received by reconfigure, and add
+        # those services which are not in the existing topic args
         for topic_name in topic_names:
             if not topic_name in self.topics_args:
                 ret = self.add_topic(topic_name, allow_pub=allow_pub, allow_sub=allow_sub)
-                # if ret: rospy.loginfo('Exposed Topic %s Pub %r Sub %r', topic_name, allow_pub, allow_sub)
 
-        # Removing extra ones
+        # look through the current topic args and delete those values which
+        # will not be valid when the args are replaced with the new ones.
         for topic_name in self.topics_args:
-            if not topic_name in topic_names:
+            if not topic_name in topic_names or not self.is_regex_match(topic_name, topic_names):
                 ret = self.del_topic(topic_name)
-                # if ret: rospy.loginfo('Removed Topic %s', topic_name)
+                self.topics_args.remove(topic_name)
 
     def get_topic(self, topic_name):
         #normalizing names... ( somewhere else ?)
@@ -325,7 +335,7 @@ class RosInterface(object):
             return None  # topic not exposed
 
     def add_action(self, action_name, action_type=None):
-        rospy.loginfo("Adding action %s" % action_name)
+        rospy.loginfo("[ros_interface] Adding action %s" % action_name)
         if action_name not in self.actions_args:
             self.action_args[action_name] = 0
         if action_type is None:
@@ -364,7 +374,7 @@ class RosInterface(object):
     This exposes a list of actions as REST API. actions not listed here will be removed from the API
     """
     def expose_actions(self, action_names):
-        rospy.loginfo('Exposing actions : %r', action_names)
+        rospy.loginfo('[ros_interface] Exposing actions : %r', action_names)
         if not action_names:
             return
         for action_name in action_names:
@@ -373,7 +383,7 @@ class RosInterface(object):
                 #if ret: rospy.loginfo( 'Exposed Action %s', action_name)
 
         for action_name in self.actions_args:
-            if not action_name in action_names:
+            if not action_name in action_names or not self.is_regex_match(action_name, action_names):
                 ret = self.del_action(action_name)
                 #if ret: rospy.loginfo ( 'Removed Action %s', action_name)
 
@@ -394,16 +404,17 @@ class RosInterface(object):
         # internal lists store topics without the initial slash, but we receive them with it from outside
         new_topics = map(self.repslash, new_topics)
         lost_topics = map(self.repslash, lost_topics)
-        rospy.logwarn('new topics : %r, lost topics : %r', new_topics, lost_topics)
+        # rospy.logwarn('new topics : %r, lost topics : %r' % (new_topics, lost_topics))
         # convert new topics to a set and then back to a list to ensure uniqueness
-        topics_lst = [t for t in list(set(new_topics)) if t in self.topics_args]
+        topics_lst = [t for t in list(set(new_topics)) if t in self.topics_args or self.is_regex_match(t, self.topics_waiting)]
         if len(topics_lst) > 0:
             # rospy.logwarn('exposing new topics : %r', topics_lst)
             # Adding missing ones
             for topic_name in topics_lst:
                 ret = self.add_topic(topic_name)
-        rospy.loginfo("Currently waiting on topics %r" % self.topics_waiting)
-
+        # rospy.loginfo("Currently waiting on topics %r" % self.topics_waiting)
+        # rospy.loginfo("current topics %r" % self.topics)
+                
         topics_lst = [t for t in lost_topics if t in self.topics_args]
         if len(topics_lst) > 0:
             # rospy.logwarn('hiding lost topics : %r', topics_lst)
@@ -426,15 +437,16 @@ class RosInterface(object):
         # internal lists store topics without the initial slash, but we receive them with it from outside
         new_services = map(self.repslash, new_services)
         lost_services = map(self.repslash, lost_services)
-        rospy.logwarn('new services : %r, lost services : %r', new_services, lost_services)
+        # rospy.logwarn('new services : %r, lost services : %r' % (new_services, lost_services))
         # convert new services to a set and then back to a list to ensure uniqueness
-        svc_list = [s for s in list(set(new_services)) if s in self.services_args]
+        svc_list = [s for s in list(set(new_services)) if s in self.services_args or self.is_regex_match(s, self.services_waiting)]
         if len(svc_list) > 0:
             # rospy.logwarn('exposing new services : %r', svc_list)
             for svc_name in svc_list:
                 self.add_service(svc_name)
-        rospy.loginfo("Currently waiting on services %r" % self.services_waiting)
-                
+        # rospy.loginfo("Currently waiting on services %r" % self.services_waiting)
+        # rospy.loginfo("current services %r" % self.services)
+
         svc_list = [s for s in lost_services if s in self.services_args]
         if len(svc_list) > 0:
             # rospy.logwarn('hiding lost services : %r', svc_list)
@@ -447,7 +459,7 @@ class RosInterface(object):
         lost_actions = map(self.repslash, lost_actions)
         # rospy.logwarn('new actions : %r, lost actions : %r', new_actions, lost_actions)
         # convert new actions to a set and then back to a list to ensure uniqueness
-        act_list = [a for a in list(set(new_actions)) if a in self.actions_args]
+        act_list = [a for a in list(set(new_actions)) if a in self.actions_args or self.is_regex_match(a, self.topics_waiting)]
         if len(act_list) > 0:
             # rospy.logwarn('exposing new actions : %r', act_list)
             for act_name in act_list:


### PR DESCRIPTION
The interface now tracks how many calls have been made to the add function and
ensures that topics are not prematurely deleted from the list. Actions also have
a similar thing going on, but not sure if it works since they are unused.
Services are unchanged.

Ensured uniqueness of topics and services being passed into the system using sets.

Removed unnecessary ws_name code.

Issue #27.
