### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/pyros/baseinterface/baseinterface.py
+++ b/src/pyros/baseinterface/baseinterface.py
@@ -43,7 +43,7 @@ class BaseInterface(object):
                 if pattern.match(key):
                     return cand
             except:
-                logging.warn('[ros_interface] Ignoring invalid regex string "%s"!' % cand)
+                logging.warn('[ros_interface] Ignoring invalid regex string "{0!s}"!'.format(cand))
 
         return None
 
@@ -60,7 +60,7 @@ class BaseInterface(object):
             pattern = re.compile(BaseInterface.cap_match_string(regex))
             matches = [cand for cand in match_candidates if pattern.match(cand)]
         except:
-            logging.warn('[ros_interface] Ignoring invalid regex string "%s"!' % regex)
+            logging.warn('[ros_interface] Ignoring invalid regex string "{0!s}"!'.format(regex))
         return matches
 
     @staticmethod

--- a/src/pyros/mockinterface/mockmessage.py
+++ b/src/pyros/mockinterface/mockmessage.py
@@ -27,15 +27,15 @@ StatusMsg = namedtuple("StatusMsg", "error code message")
 # defining Exceptions
 class NonexistentFieldException(Exception):
     def __init__(self, oridict, basetype, message):
-        Exception.__init__(self, "Trying to convert %s to Message type %s triggered %s" % (oridict, basetype, message))
+        Exception.__init__(self, "Trying to convert {0!s} to Message type {1!s} triggered {2!s}".format(oridict, basetype, message))
 
 
 class FieldTypeMismatchException(Exception):
     def __init__(self, roottype, fields, expected_type, found_type):
         if roottype == expected_type:
-            Exception.__init__(self, "Expected a Python object for type %s but received a %s" % (roottype, found_type))
+            Exception.__init__(self, "Expected a Python object for type {0!s} but received a {1!s}".format(roottype, found_type))
         else:
-            Exception.__init__(self, "%s message requires a %s for field %s, but got a %s" % (roottype, expected_type, '.'.join(fields), found_type))
+            Exception.__init__(self, "{0!s} message requires a {1!s} for field {2!s}, but got a {3!s}".format(roottype, expected_type, '.'.join(fields), found_type))
 
 
 def extract_values(inst):

--- a/src/pyros/rosinterface/deffile.py
+++ b/src/pyros/rosinterface/deffile.py
@@ -76,7 +76,7 @@ class DefFile(object):
                 if quiet:
                     return False
                 else:
-                    raise TypeError("%s:%s definition already exists" % (dfn.type, dfn.name))
+                    raise TypeError("{0!s}:{1!s} definition already exists".format(dfn.type, dfn.name))
         self.definitions.append(dfn)
         if quiet:
             return True
@@ -122,20 +122,20 @@ class DefFile(object):
         if self.manifest:
             s = ''
             if self.format and not suppress_formats:
-                s += '[Manifest!%s]\n' % self.format
+                s += '[Manifest!{0!s}]\n'.format(self.format)
             else:
                 s += '[Manifest]\n'
             s += self.manifest.__str__()
             strs.append(s)
         elif self.format and not suppress_formats:
-            strs.append('[Manifest!%s]' % self.format)
+            strs.append('[Manifest!{0!s}]'.format(self.format))
         
         for dfn in self.definitions:
             s = ''
             if dfn.format and not suppress_formats:
-                s += '[%s:%s!%s]\n' % (dfn.type, dfn.name, dfn.format)
+                s += '[{0!s}:{1!s}!{2!s}]\n'.format(dfn.type, dfn.name, dfn.format)
             else:
-                s += '[%s:%s]\n' % (dfn.type, dfn.name)
+                s += '[{0!s}:{1!s}]\n'.format(dfn.type, dfn.name)
             s += dfn.__str__()
             strs.append(s)
         
@@ -145,9 +145,9 @@ class DefFile(object):
             if sec_name.find(':') != -1:
                 sec_name = ':' + sec_name
             if section.format and not suppress_formats:
-                s += '[%s!%s]\n' % (sec_name, section.format)
+                s += '[{0!s}!{1!s}]\n'.format(sec_name, section.format)
             else:
-                s += '[%s]\n' % sec_name
+                s += '[{0!s}]\n'.format(sec_name)
             s += section.__str__()
             strs.append(s)
         
@@ -168,7 +168,7 @@ class DefFile(object):
             null_sec_val = self.get_section(None).__getitem__(key) if self.has_section(None) and hasattr(self.get_section(None),'__getitem__') else None
             if (self.manifest and key in self.manifest 
                 and null_sec_val is not None):
-                raise RuntimeError('Manifest and null section both have key %s!' % str(key))
+                raise RuntimeError('Manifest and null section both have key {0!s}!'.format(str(key)))
             elif null_sec_val is not None:
                 return null_sec_val
             elif not self.manifest:
@@ -230,7 +230,7 @@ class DefFile(object):
                     pass
             if (self.manifest and key in self.manifest 
                 and null_sec_val is True):
-                raise RuntimeError('Manifest and null section both have key %s!' % str(key))
+                raise RuntimeError('Manifest and null section both have key {0!s}!'.format(str(key)))
             elif null_sec_val is not None:
                 return null_sec_val
             elif not self.manifest:
@@ -245,7 +245,7 @@ class DefFile(object):
         return self.tostring()
     
     def __repr__(self):
-        return 'DefFile(format=%s,manifest=%s,definitions=%s,sections=%s)' % (repr(self.format),repr(self.manifest),repr(self.definitions),repr(self.sections))
+        return 'DefFile(format={0!s},manifest={1!s},definitions={2!s},sections={3!s})'.format(repr(self.format), repr(self.manifest), repr(self.definitions), repr(self.sections))
                 
 
 class Manifest(object):
@@ -263,23 +263,23 @@ class Manifest(object):
     def tostring(self):
         strs = []
         if self.def_type is not None:
-            strs.append('Def-Type = %s' % self.def_type)
+            strs.append('Def-Type = {0!s}'.format(self.def_type))
         for include_file, include_type in self.includes:
             if include_type:
-                strs.append('Include.%s = %s' % (include_type, include_file))
+                strs.append('Include.{0!s} = {1!s}'.format(include_type, include_file))
             else:
-                strs.append('Include = %s' % include_file)
+                strs.append('Include = {0!s}'.format(include_file))
         for key, value in self.fields.iteritems():
-            strs.append('%s = %s' % (key,value))
+            strs.append('{0!s} = {1!s}'.format(key, value))
         return '\n'.join(strs)
     
     def __str__(self):
         return self.tostring()
     
     def __repr__(self):
-        def_type_str = ',%s' % repr(self.def_type) if self.def_type is not None else ''
-        includes_str = ',%s' % repr(self.includes) if self.includes else ''
-        return 'Manifest(fields=%s%s%s)' % (repr(self.fields), def_type_str, includes_str)
+        def_type_str = ',{0!s}'.format(repr(self.def_type)) if self.def_type is not None else ''
+        includes_str = ',{0!s}'.format(repr(self.includes)) if self.includes else ''
+        return 'Manifest(fields={0!s}{1!s}{2!s})'.format(repr(self.fields), def_type_str, includes_str)
     
     def __iter__(self):
         return self.fields.iteritems()
@@ -393,10 +393,10 @@ class INISection(Section):
         strs = []
         for key, value in self.fields.iteritems():
             if value.find('\n') != -1:
-                strs.append("%s = |" % key)
+                strs.append("{0!s} = |".format(key))
                 [strs.append(re.sub(r'=',r'\\=',line)) for line in value.split('\n')]
             else:
-                strs.append('%s = %s' % (key,value))
+                strs.append('{0!s} = {1!s}'.format(key, value))
         return '\n'.join(strs)
     
     @staticmethod
@@ -409,7 +409,7 @@ class INISection(Section):
         return ini
     
     def __repr__(self):
-        return 'INISection(%s, fields=%s)' % (repr(self.name), repr(self.fields))
+        return 'INISection({0!s}, fields={1!s})'.format(repr(self.name), repr(self.fields))
     
     def __iter__(self):
         return self.fields.iteritems()
@@ -476,7 +476,7 @@ class RawSection(Section):
         return self.content
     
     def __repr__(self):
-        return 'RawSection(%s,content=%s)' % (repr(self.name), repr(self.content))
+        return 'RawSection({0!s},content={1!s})'.format(repr(self.name), repr(self.content))
 
 def get_definition_from_section(section_class):
     sec_class_name = section_class.__name__
@@ -488,7 +488,7 @@ def get_definition_from_section(section_class):
         
         def __repr__(self):
             sec_repr = section_class.__repr__(self)
-            return sec_repr.replace('%s(' % sec_class_name,'%s(%s,' % (dfn_class_name,repr(self.type)))
+            return sec_repr.replace('{0!s}('.format(sec_class_name),'{0!s}({1!s},'.format(dfn_class_name, repr(self.type)))
     DfnClass.__name__ = dfn_class_name
     return DfnClass
 
@@ -512,7 +512,7 @@ class ROSStyleDefinition(Definition):
         for idx, seg_name in enumerate(self.segment_names):
             if seg_name == index:
                 return self.segment(idx)
-        raise IndexError("No segment named %s" % index)
+        raise IndexError("No segment named {0!s}".format(index))
              
     def __getitem__(self,index):
         if len(self.segments) == 1:
@@ -534,12 +534,12 @@ class ROSStyleDefinition(Definition):
         for segment in self.segments:
             strs = []
             for name, type in segment:
-                strs.append('%s %s' % (type, name))
+                strs.append('{0!s} {1!s}'.format(type, name))
             segment_strs.append('\n'.join(strs))
         return '\n----\n'.join(segment_strs)
     
     def __repr__(self):
-        return 'ROSStyleDefinition(%s,%s,%s,segment_values=%s)' % (repr(self.type),repr(self.name),repr(self.segment_names),repr(self.segments))
+        return 'ROSStyleDefinition({0!s},{1!s},{2!s},segment_values={3!s})'.format(repr(self.type), repr(self.name), repr(self.segment_names), repr(self.segments))
 
 
 class DefFileParser(object):
@@ -621,9 +621,9 @@ class DefFileParser(object):
             if go_easy:
                 return None
             elif format:
-                raise ParsingError('No section parser for section %s and format %s' % (name,format))
+                raise ParsingError('No section parser for section {0!s} and format {1!s}'.format(name, format))
             else:
-                raise ParsingError('No section parser for section %s' % name)
+                raise ParsingError('No section parser for section {0!s}'.format(name))
         return matches[max(matches.keys())](name,format,self._get_reader())
     
     def add_definition_parser(self,parser, dfn_type, format, def_file_format=None):
@@ -652,9 +652,9 @@ class DefFileParser(object):
             if go_easy:
                 return None
             elif format:
-                raise ParsingError('No definition parser for type %s and format %s' % (dfn_type,format))
+                raise ParsingError('No definition parser for type {0!s} and format {1!s}'.format(dfn_type, format))
             else:
-                raise ParsingError('No definition parser for type %s' % dfn_type)
+                raise ParsingError('No definition parser for type {0!s}'.format(dfn_type))
         return matches[max(matches.keys())](dfn_type,name,format,self._get_reader())
     
     def readline(self,new=True):
@@ -680,7 +680,7 @@ class DefFileParser(object):
                     sec = parser.parse()
                     section_info = {'section': None, 'data': sec}
                 else:
-                    raise ParsingError('Parsing error: invalid section line\n%s' % line)
+                    raise ParsingError('Parsing error: invalid section line\n{0!s}'.format(line))
             self.null_section = False
             yield section_info
             line = self.readline(new=False)
@@ -732,7 +732,7 @@ class DefFileParser(object):
         if not def_file.type and self.default_def_type:
             def_file.type = self.default_def_type
         if self.require_def_type and not re.match(self.require_def_type,def_file.type):
-            raise ParsingError("Require def file type %s, got %s" % (self.require_def_type,def_file.type))
+            raise ParsingError("Require def file type {0!s}, got {1!s}".format(self.require_def_type, def_file.type))
         self.fp = None
         self.current_line = 0
         return def_file
@@ -973,7 +973,7 @@ class ROSStyleDefinitionParser(DefFileParser.DefinitionParser):
         else:
             segs.append(segment)
         if num_segments and len(segs) != num_segments:
-            raise ParsingError('Parsing error: This ROS-style definition is required to have %d segments: %s' % (num_segments, self.SEGMENT_NAMES))
+            raise ParsingError('Parsing error: This ROS-style definition is required to have {0:d} segments: {1!s}'.format(num_segments, self.SEGMENT_NAMES))
         rosdef.segments = tuple(segs)
         if not num_segments:
             rosdef.segment_names = tuple(str(i) for i in xrange(len(segs)))

--- a/src/pyros/rosinterface/message_conversion.py
+++ b/src/pyros/rosinterface/message_conversion.py
@@ -44,7 +44,7 @@ from base64 import standard_b64encode, standard_b64decode
 # Utils function to get message type from ros or its dict representation
 #outputs message structure as string (useful ?)
 def get_msg(msg):
-    return '\n'.join(['%s %s' % line for line in zip(msg._slot_types, msg.__slots__)])
+    return '\n'.join(['{0!s} {1!s}'.format(*line) for line in zip(msg._slot_types, msg.__slots__)])
 
 #outputs message structure as dict
 def get_msg_dict(msg):
@@ -77,7 +77,7 @@ class InvalidMessageException(PyrosException):
     def __init__(self, inst):
         super(InvalidMessageException, self).__init__(inst)
         self.inst = inst
-        self.excmsg = "Unable to extract message values from %s instance" % type(inst).__name__
+        self.excmsg = "Unable to extract message values from {0!s} instance".format(type(inst).__name__)
 
     @property
     def message(self):
@@ -91,7 +91,7 @@ class NonexistentFieldException(PyrosException):
         super(NonexistentFieldException, self).__init__(basetype, fields)
         self.basetype = basetype
         self.fields = fields
-        self.excmsg = "Message type %s does not have a field %s" % (basetype, '.'.join(fields))
+        self.excmsg = "Message type {0!s} does not have a field {1!s}".format(basetype, '.'.join(fields))
 
     @property
     def message(self):
@@ -109,9 +109,9 @@ class FieldTypeMismatchException(Exception):
         self.found_type = found_type
 
         if roottype == expected_type:
-            self.excmsg = "Expected a JSON object for type %s but received a %s" % (roottype, found_type)
+            self.excmsg = "Expected a JSON object for type {0!s} but received a {1!s}".format(roottype, found_type)
         else:
-            self.excmsg = "%s message requires a %s for field %s, but got a %s" % (roottype, expected_type, '.'.join(fields), found_type)
+            self.excmsg = "{0!s} message requires a {1!s} for field {2!s}, but got a {3!s}".format(roottype, expected_type, '.'.join(fields), found_type)
 
     @property
     def message(self):
@@ -310,30 +310,27 @@ _srvs_lock = Lock()
 
 class InvalidTypeStringException(Exception):
     def __init__(self, typestring):
-        Exception.__init__(self, "%s is not a valid type string" % typestring)
+        Exception.__init__(self, "{0!s} is not a valid type string".format(typestring))
 
 
 class InvalidPackageException(Exception):
     def __init__(self, package, original_exception):
         Exception.__init__(self,
-           "Unable to load the manifest for package %s. Caused by: %s"
-           % (package, original_exception.message)
+           "Unable to load the manifest for package {0!s}. Caused by: {1!s}".format(package, original_exception.message)
        )
 
 
 class InvalidModuleException(Exception):
     def __init__(self, modname, subname, original_exception):
         Exception.__init__(self,
-           "Unable to import %s.%s from package %s. Caused by: %s"
-           % (modname, subname, modname, str(original_exception))
+           "Unable to import {0!s}.{1!s} from package {2!s}. Caused by: {3!s}".format(modname, subname, modname, str(original_exception))
         )
 
 
 class InvalidClassException(Exception):
     def __init__(self, modname, subname, classname, original_exception):
         Exception.__init__(self,
-           "Unable to import %s class %s from package %s. Caused by %s"
-           % (subname, classname, modname, str(original_exception))
+           "Unable to import {0!s} class {1!s} from package {2!s}. Caused by {3!s}".format(subname, classname, modname, str(original_exception))
         )
 
 
@@ -404,7 +401,7 @@ def _load_class(modname, subname, classname):
         raise InvalidPackageException(modname, exc)
 
     try:
-        pypkg = __import__('%s.%s' % (modname, subname))
+        pypkg = __import__('{0!s}.{1!s}'.format(modname, subname))
     except Exception as exc:
         raise InvalidModuleException(modname, subname, exc)
 

--- a/src/pyros/rosinterface/pyros_ros.py
+++ b/src/pyros/rosinterface/pyros_ros.py
@@ -8,7 +8,7 @@ try:
     _ROCON_AVAILABLE = True
 except ImportError, e:
     import logging
-    logging.warn("Error: could not import RoconInterface - disabling. %s" % e)
+    logging.warn("Error: could not import RoconInterface - disabling. {0!s}".format(e))
     _ROCON_AVAILABLE = False
 
 import zmp

--- a/src/pyros/rosinterface/roconinterface/interaction.py
+++ b/src/pyros/rosinterface/roconinterface/interaction.py
@@ -69,5 +69,5 @@ class Interaction(rocon_interactions.Interaction):
           Format the interaction into a human-readable string.
         '''
         s = rocon_interactions.Interaction.__str__(self)
-        s += console.cyan + "  Launch List" + console.reset + "  : " + console.yellow + "%s" % self.launch_list.keys() + console.reset + '\n'  # noqa
+        s += console.cyan + "  Launch List" + console.reset + "  : " + console.yellow + "{0!s}".format(self.launch_list.keys()) + console.reset + '\n'  # noqa
         return s

--- a/src/pyros/rosinterface/roconinterface/interaction_table.py
+++ b/src/pyros/rosinterface/roconinterface/interaction_table.py
@@ -111,7 +111,7 @@ class InteractionsTable(object):
         if not matches:
             self.interactions.append(interaction)
         else:
-            console.logwarn("Interactions Table : tried to append an already existing interaction [%s]" % interaction.hash)
+            console.logwarn("Interactions Table : tried to append an already existing interaction [{0!s}]".format(interaction.hash))
 
     def find(self, interaction_hash):
         '''

--- a/src/pyros/rosinterface/roconinterface/interaction_watcher.py
+++ b/src/pyros/rosinterface/roconinterface/interaction_watcher.py
@@ -77,7 +77,7 @@ class InteractionWatcher(threading.Thread):  #TODO : DO NOT inherit from thread.
 
         for service_name in iamgr_services.keys():
             if not rocon_python_comms.service_is_available(iamgr_services[service_name]):
-                raise rocon_python_comms.NotFoundException("'%s' service is not validated" % service_name)
+                raise rocon_python_comms.NotFoundException("'{0!s}' service is not validated".format(service_name))
 
         if not self.get_interactions_service_proxy :
             self.get_interactions_service_proxy = rospy.ServiceProxy(iamgr_services['get_interactions'], rocon_interaction_srvs.GetInteractions)

--- a/src/pyros/rosinterface/roconinterface/rocon_interface.py
+++ b/src/pyros/rosinterface/roconinterface/rocon_interface.py
@@ -187,7 +187,7 @@ class RoconInterface(object):
 
             return output_data
         except rospy.ServiceException, e:
-            print "Rapp start call failed: %r" % e
+            print "Rapp start call failed: {0!r}".format(e)
 
     def stop_rapp(self):
         try:
@@ -205,7 +205,7 @@ class RoconInterface(object):
 
             return output_data
         except rospy.ServiceException, e:
-            print "Rapp stop call failed: %r" % e
+            print "Rapp stop call failed: {0!r}".format(e)
 
 
 

--- a/src/pyros/rosinterface/ros_loader.py
+++ b/src/pyros/rosinterface/ros_loader.py
@@ -52,30 +52,27 @@ _srvs_lock = Lock()
 
 class InvalidTypeStringException(Exception):
     def __init__(self, typestring):
-        Exception.__init__(self, "%s is not a valid type string" % typestring)
+        Exception.__init__(self, "{0!s} is not a valid type string".format(typestring))
 
 
 class InvalidPackageException(Exception):
     def __init__(self, package, original_exception):
         Exception.__init__(self,
-           "Unable to load the manifest for package %s. Caused by: %s"
-           % (package, original_exception.message)
+           "Unable to load the manifest for package {0!s}. Caused by: {1!s}".format(package, original_exception.message)
        )
 
 
 class InvalidModuleException(Exception):
     def __init__(self, modname, subname, original_exception):
         Exception.__init__(self,
-           "Unable to import %s.%s from package %s. Caused by: %s"
-           % (modname, subname, modname, str(original_exception))
+           "Unable to import {0!s}.{1!s} from package {2!s}. Caused by: {3!s}".format(modname, subname, modname, str(original_exception))
         )
 
 
 class InvalidClassException(Exception):
     def __init__(self, modname, subname, classname, original_exception):
         Exception.__init__(self,
-           "Unable to import %s class %s from package %s. Caused by %s"
-           % (subname, classname, modname, str(original_exception))
+           "Unable to import {0!s} class {1!s} from package {2!s}. Caused by {3!s}".format(subname, classname, modname, str(original_exception))
         )
 
 
@@ -184,7 +181,7 @@ def _load_class(modname, subname, classname):
         raise InvalidPackageException(modname, exc)
 
     try:
-        pypkg = __import__('%s.%s' % (modname, subname))
+        pypkg = __import__('{0!s}.{1!s}'.format(modname, subname))
     except Exception as exc:
         raise InvalidModuleException(modname, subname, exc)
 

--- a/src/pyros/rosinterface/rostests/nodes/string_echo_node.py
+++ b/src/pyros/rosinterface/rostests/nodes/string_echo_node.py
@@ -42,19 +42,19 @@ if __name__ == '__main__':
         rospy.loginfo('String Echo node started. [' + rospy.get_name() + ']')
 
         topic_name = rospy.get_param("~topic_name", "topic")
-        print 'Parameter %s has value %s' % (rospy.resolve_name('~topic_name'), topic_name)
+        print 'Parameter {0!s} has value {1!s}'.format(rospy.resolve_name('~topic_name'), topic_name)
         if topic_name == "":
             print "{0} parameter not found".format(rospy.resolve_name('~topic_name'))
             raise common.TestArgumentNotFound
 
         echo_topic_name = rospy.get_param("~echo_topic_name", "echo_topic")
-        print 'Parameter %s has value %s' % (rospy.resolve_name('~echo_topic_name'), echo_topic_name)
+        print 'Parameter {0!s} has value {1!s}'.format(rospy.resolve_name('~echo_topic_name'), echo_topic_name)
         if echo_topic_name == "":
             print "{0} parameter not found".format(rospy.resolve_name('~echo_topic_name'))
             raise common.TestArgumentNotFound
 
         echo_service_name = rospy.get_param("~echo_service_name", "echo_service")
-        print 'Parameter %s has value %s' % (rospy.resolve_name('~echo_service_name'), echo_service_name)
+        print 'Parameter {0!s} has value {1!s}'.format(rospy.resolve_name('~echo_service_name'), echo_service_name)
         if echo_service_name == "":
             print "{0} parameter not found".format(rospy.resolve_name('~echo_service_name'))
             raise common.TestArgumentNotFound

--- a/src/pyros/rosinterface/rostests/nodes/string_pub_node.py
+++ b/src/pyros/rosinterface/rostests/nodes/string_pub_node.py
@@ -15,12 +15,12 @@ if __name__ == '__main__':
         rospy.loginfo('String Pub node started. [' + rospy.get_name() + ']')
 
         topic_name = rospy.get_param("~topic_name", "")
-        print 'Parameter %s has value %s' % (rospy.resolve_name('~topic_name'), topic_name)
+        print 'Parameter {0!s} has value {1!s}'.format(rospy.resolve_name('~topic_name'), topic_name)
         if topic_name == "":
             print "{0} parameter not found".format(rospy.resolve_name('~topic_name'))
             raise common.TestArgumentNotFound
         test_message = rospy.get_param("~test_message", "")
-        print 'Parameter %s has value %s' % (rospy.resolve_name('~test_message'), test_message)
+        print 'Parameter {0!s} has value {1!s}'.format(rospy.resolve_name('~test_message'), test_message)
         if test_message == "":
             print "{0} parameter not found".format(rospy.resolve_name('~test_message'))
             raise common.TestArgumentNotFound

--- a/src/pyros/rosinterface/rostests/nodes/string_slow_node.py
+++ b/src/pyros/rosinterface/rostests/nodes/string_slow_node.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
         rospy.loginfo('String Slow node started. [' + rospy.get_name() + ']')
 
         slow_service_name = rospy.get_param("~slow_service_name", "slow_service")
-        print 'Parameter %s has value %s' % (rospy.resolve_name('~slow_service_name'), slow_service_name)
+        print 'Parameter {0!s} has value {1!s}'.format(rospy.resolve_name('~slow_service_name'), slow_service_name)
         if slow_service_name == "":
             print "{0} parameter not found".format(rospy.resolve_name('~slow_service_name'))
             raise common.TestArgumentNotFound

--- a/src/pyros/rosinterface/rostests/testService.py
+++ b/src/pyros/rosinterface/rostests/testService.py
@@ -80,7 +80,7 @@ class TestService(unittest.TestCase):
     def logPoint(self):
         currentTest = self.id().split('.')[-1]
         callingFunction = inspect.stack()[1][3]
-        print 'in %s - %s()' % (currentTest, callingFunction)
+        print 'in {0!s} - {1!s}()'.format(currentTest, callingFunction)
 
     def service_wait_type(self, service_name, retries=5, retrysleep=1):
         resolved_service_name = rospy.resolve_name(service_name)

--- a/src/pyros/rosinterface/rostests/testStringTopic.py
+++ b/src/pyros/rosinterface/rostests/testStringTopic.py
@@ -91,7 +91,7 @@ class TestStringTopic(unittest.TestCase):
     def logPoint(self):
         currentTest = self.id().split('.')[-1]
         callingFunction = inspect.stack()[1][3]
-        print 'in %s - %s()' % (currentTest, callingFunction)
+        print 'in {0!s} - {1!s}()'.format(currentTest, callingFunction)
 
     def msg_extract(self, topic, retries=5, retrysleep=1):
         msg = topic.get()

--- a/src/pyros/rosinterface/util.py
+++ b/src/pyros/rosinterface/util.py
@@ -21,5 +21,5 @@ def load_type(msg_type_name):
     if not hasattr(msg_module,type_name) and (type_name.endswith('Request') or type_name.endswith('Response')):
         msg_module = import_module(module_name + '.srv')
     if not hasattr(msg_module,type_name):
-        raise TypeError('Unknown ROS msg %s' % msg_type_name)
+        raise TypeError('Unknown ROS msg {0!s}'.format(msg_type_name))
     return getattr(msg_module,type_name)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:asmodehn:pyros?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:asmodehn:pyros?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
