### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/src/pyros/rosinterface/deffile.py
+++ b/src/pyros/rosinterface/deffile.py
@@ -111,9 +111,9 @@ class DefFile(object):
         
         d['Manifest'] = self.manifest.tojson()
         
-        d['Definitions'] = dict([(dfn.type + ':' + dfn.name, dfn.tojson()) for dfn in self.definitions])
+        d['Definitions'] = {dfn.type + ':' + dfn.name: dfn.tojson() for dfn in self.definitions}
         
-        d['Sections'] = dict([(section_name, section.tojson()) for section_name, section in self.sections.iteritems()])
+        d['Sections'] = {section_name: section.tojson() for section_name, section in self.sections.iteritems()}
         
         return d
     


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:asmodehn:pyros?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:asmodehn:pyros?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
